### PR TITLE
ci: Publish releases to PyPI through GitHub releases

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -33,6 +33,6 @@ jobs:
       run: twine check dist/*
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'madjax-hep/madjax'
-      uses: pypa/gh-action-pypi-publish@v1.4.1
+      uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This PR uses publication type releases to publish to PyPI by running the publication workflow on `published` `release` events and then verifying that the PyPI upload step is running on one.

- Locally on `master` run:

```
$ git checkout master && git pull # verify that you're on master and synced with GitHub
$ bump2version <part> # bump the version and create a commit and tag
$ git push origin master --tags # push the commit and the tag to GitHub, causing TestPyPI to publish
```
- Then on GitHub:
   1. Go to releases: https://github.com/madjax-hep/madjax releases
   2. Click "Draft a new release"
   3. On the new page enter the tag you just pushed (e.g. `v0.0.2`) in the "Tag version" box and the "Release title" box (to make it easy unless you really want to get descriptive)
   4. Enter any release notes and click "Publish release"
- This then kicks of the publication CD workflow that will use the PyPI API key to publish.

This is the [same workflow that `pylhe` uses](https://github.com/scikit-hep/pylhe/pull/44) and so requires setting an API key as the value of the `PYPI_PASSWORD` GitHub secret.

```
* Publish to PyPI through published release events triggered through GitHub releases
   - c.f. https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#release
```