### PR TITLE
ci: Use madgraph5 container Python for runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
-      # image: ubuntu:20.04
-      # options: --user root
+      options: --user root
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
To temporarily avoid Issue #12, drop testing across all Python runtimes in favor of testing with the Python runtime provided by the `scailfin/madgraph5-amc-nlo` Docker images used in CI.

```
* Drop testing across all supported Python runtimes and use container Python runtime for tests
   - Temporarily mitigate Issue #12
   - Run container as root as scailfin/madgraph5-amc-nlo Docker images for mg5_aMC v2.9+ use non-root default users
```