### PR TITLE
fix: Get Dockerfile builds working with modern MadGraph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container:
-      image: scailfin/madgraph5-amc-nlo:mg5_amc2.9.2
+      image: scailfin/madgraph5-amc-nlo:mg5_amc3.5.0
       options: --user root
     strategy:
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Build Docker image
       uses: docker/build-push-action@v1
       with:
-        repository: madjax/madjax
+        repository: madjax-hep/madjax
         dockerfile: docker/Dockerfile
         tags: test
         tag_with_sha: true
@@ -28,4 +28,4 @@ jobs:
     - name: Run CLI API check
       run: |
         printf "\nmadjax-config\n"
-        docker run --rm madjax/madjax:test "madjax-config"
+        docker run --rm madjax-hep/madjax:test "madjax-config"

--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ python -m pip install madjax
 ```
 
 `madjax` relies on `MadGraph` for code generation using its plugin. The recommended
-way to do this is through the use of official `madjax` docker images
+way to do this is to build a `madjax` docker image
 
 ```console
-docker pull madjax-hep/madjax
+docker build --file docker/Dockerfile --tag madjax-hep/madjax:local .
+# you can also just run make
 ```
 
 It is also possible to use `madjax` with a local `MadGraph` install.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ python -m pip install madjax
 way to do this is through the use of official `madjax` docker images
 
 ```console
-docker pull madjax/madjax
+docker pull madjax-hep/madjax
 ```
 
 It is also possible to use `madjax` with a local `MadGraph` install.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ COPY --chown=moby . /code
 # hadolint ignore=DL3003
 RUN cd /code && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
-    python -m pip install --no-cache-dir --verbose . && \
+    python -m pip install --no-cache-dir . && \
     python -m pip list && \
     cp -r "$(madjax-config)" "$(dirname $(dirname $(command -v mg5_aMC)))/PLUGIN/"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,14 +2,16 @@ ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo:mg5_amc3.5.0
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 
-COPY . /code
+USER moby
+
+COPY --chown=moby . /code
 
 # hadolint ignore=DL3003
 RUN cd /code && \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel && \
-    python -m pip install --no-cache-dir . && \
+    python -m pip install --no-cache-dir --verbose . && \
     python -m pip list && \
-    cp -r "$(madjax-config)" /usr/local/MG5_aMC_v2_8_1/PLUGIN/
+    cp -r "$(madjax-config)" "$(dirname $(dirname $(command -v mg5_aMC)))/PLUGIN/"
 
 ENTRYPOINT ["/bin/bash", "-l", "-c"]
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo:mg5_amc2.8.1
+ARG BASE_IMAGE=scailfin/madgraph5-amc-nlo:mg5_amc3.5.0
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE} as base
 


### PR DESCRIPTION
```
* Use scailfin/madgraph5-amc-nlo:mg5_amc3.5.0 as the base image.
   - Determine PLUGIN directory path at image build time.
* Recommend that users build Docker image locally.
```