### PR TITLE
feat: Add Makefile for building Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+default: image
+
+image:
+	docker build \
+		--file docker/Dockerfile \
+		--build-arg BASE_IMAGE=scailfin/madgraph5-amc-nlo:mg5_amc3.5.0 \
+		--tag madjax-hep/madjax:local \
+		.


### PR DESCRIPTION
* Add Makefile with 'image' target to build the Docker image.
* Amends PR #19.